### PR TITLE
Changes for Ubuntu 22.04 Jammy Jellyfish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1>linux_joindomain</h1>
-This is an ansible role to automaticaly join Linux Machine CentOS and Redhat using sssd, realm, samba and winbind. This role is tested on RedHat/CentOS 7.x, 8.x 6.6 and Ubuntu 20 18 16 and Debian 10 9
+This is an ansible role to automaticaly join Linux Machine CentOS and Redhat using sssd, realm, samba and winbind. This role is tested on RedHat/CentOS 7.x, 8.x 6.6 and Ubuntu 22 20 18 16 and Debian 10 9
 
 # Requirements
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,6 +19,7 @@ galaxy_info:
       - stretch
   - name: Ubuntu
     versions:
+      - jammy
       - focal
       - bionic
       - xenial

--- a/vars/Debian-22.yml
+++ b/vars/Debian-22.yml
@@ -1,0 +1,15 @@
+---
+# vars file for CentOSJoinDomain
+package:
+  - sssd
+  - sssd-tools
+  - libnss-sss
+  - libpam-sss
+  - realmd 
+  - oddjob 
+  - oddjob-mkhomedir 
+  - adcli 
+  - samba-common 
+  - samba-common-bin 
+  - packagekit
+  - python3-pexpect


### PR DESCRIPTION
Ubuntu 22.04 doesn't ship Python 2 and the packages related to it don't exist anymore.